### PR TITLE
Feat/ci build gpu cpu

### DIFF
--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ linux, feat/ci-build-gpu-cpu ]
+    branches: [ linux ]
   pull_request:
-    branches: [ linux, feat/ci-build-gpu-cpu ]
+    branches: [ linux ]
 
 env:
   BUILD_TYPE: Release
@@ -15,13 +15,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-
-    - name: Cache Cuda Installer 11-5-1
-      id: cache-cuda-installer-11-5-1
-      uses: actions/cache@v2
-      with:
-        path: /opt/hostedtoolcache/cuda_installer-linux/11.5.1/x64/
-        key: ${{ runner.os }}-cuda_installer-11-5-1
 
     - uses: Jimver/cuda-toolkit@v0.2.5
       id: cuda-toolkit

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -16,6 +16,13 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
+    - name: Cache Cuda Installer 11-5-1
+      id: cache-cuda-installer-11-5-1
+      uses: actions/cache@v2
+      with:
+        path: /opt/hostedtoolcache/cuda_installer-linux/11.5.1/x64/
+        key: ${{ runner.os }}-cuda_installer-11-5-1
+
     - uses: Jimver/cuda-toolkit@v0.2.5
       id: cuda-toolkit
       with:
@@ -35,3 +42,15 @@ jobs:
 
     - name: Build CPU
       run: cmake --build ${{github.workspace}}/build-cpu --config ${{env.BUILD_TYPE}}
+
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: aquaminer-gpu
+        path: ${{github.workspace}}/build-gpu/aquaminer-gpu
+
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: aquaminer-cpu
+        path: ${{github.workspace}}/build-cpu/aquaminer-gpu

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -1,0 +1,34 @@
+name: CMake
+
+on:
+  push:
+    branches: [ linux ]
+  pull_request:
+    branches: [ linux ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: Jimver/cuda-toolkit@v0.2.5
+      id: cuda-toolkit
+      with:
+        cuda: '11.5.1'
+
+    - uses: actions/checkout@v2
+
+    - name: Configure CMake GPU
+      run: cmake -B ${{github.workspace}}/build-gpu -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DWITH_GPU=ON
+
+    - name: Build GPU
+      run: cmake --build ${{github.workspace}}/build-gpu --config ${{env.BUILD_TYPE}}
+
+    - name: Configure CMake CPU
+      run: cmake -B ${{github.workspace}}/build-cpu -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DWITH_GPU=OFF
+
+    - name: Build GPU
+      run: cmake --build ${{github.workspace}}/build-cpu --config ${{env.BUILD_TYPE}}

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -14,12 +14,15 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+    - uses: actions/checkout@v2
+
     - uses: Jimver/cuda-toolkit@v0.2.5
       id: cuda-toolkit
       with:
         cuda: '11.5.1'
 
-    - uses: actions/checkout@v2
+    - name: Update submodules
+      run: git submodule update --init
 
     - name: Configure CMake GPU
       run: cmake -B ${{github.workspace}}/build-gpu -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DWITH_GPU=ON

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -47,10 +47,10 @@ jobs:
       uses: actions/upload-artifact@v2
       with:
         name: aquaminer-gpu
-        path: ${{github.workspace}}/build-gpu/aquaminer-gpu
+        path: ${{github.workspace}}/build-gpu/aquacppminer-gpu
 
     - name: Archive code coverage results
       uses: actions/upload-artifact@v2
       with:
         name: aquaminer-cpu
-        path: ${{github.workspace}}/build-cpu/aquaminer-gpu
+        path: ${{github.workspace}}/build-cpu/aquacppminer-gpu

--- a/.github/workflows/cmake.yml
+++ b/.github/workflows/cmake.yml
@@ -2,9 +2,9 @@ name: CMake
 
 on:
   push:
-    branches: [ linux ]
+    branches: [ linux, feat/ci-build-gpu-cpu ]
   pull_request:
-    branches: [ linux ]
+    branches: [ linux, feat/ci-build-gpu-cpu ]
 
 env:
   BUILD_TYPE: Release
@@ -30,5 +30,5 @@ jobs:
     - name: Configure CMake CPU
       run: cmake -B ${{github.workspace}}/build-cpu -DCMAKE_BUILD_TYPE=${{env.BUILD_TYPE}}  -DWITH_GPU=OFF
 
-    - name: Build GPU
+    - name: Build CPU
       run: cmake --build ${{github.workspace}}/build-cpu --config ${{env.BUILD_TYPE}}


### PR DESCRIPTION
A _Github Actions_ workflow has been created for ensuring that the project compiles as expected for different configurations by using _Ubuntu_ as its base image. The _CUDA_ toolkit has been added as well for ensuring that `nvcc` is usable, but there is no GPU acceleration toolkit or `WITH_GPU` option present in the `linux` branch application source code yet.

Kindly review https://github.com/sisco0/aquaminer-gpu/actions for having an idea of CI times and successful runs.

Solves the first task of #3.